### PR TITLE
Add support for Puppet 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rvm:
   - 2.1.9
 env:
   - PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
+  - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
 matrix:
   fast_finish: true
   include:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2018-03-16 Release 1.0.0
+- Move to version 1.0.0
+- Support for Puppet 5
+
 2017-11-13 Release 0.1.0
 - Initial release of the module WildFly for the Puppet Forge
 - Based on biemond-wildfly and puppetlabs-tomcat

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "kpn-wildfly",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "author": "kpn",
   "summary": "WildFly multi-instance module",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.5.0 <5.0.0"
+      "version_requirement": ">=4.7.0 <6.0.0"
     }
   ],
   "kpn_quality_label": "A",


### PR DESCRIPTION
Fix the metadata.json and add travis-check for
Puppet 5. Bump to 1.0.0 after this, so to get
off the 0.1.0 release.